### PR TITLE
Add missing code doc for delete functions and write readme sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # go-kube
-go-kube is a wrapper over the kubectl commands such that we can have a nice interface that we can call from our go code
+go-kube is a wrapper over the kubectl commands such that we can have a nice interface that we can call from our go code.
+
+**Why is this repo created?**
+
+We (@andreaswachs and @Arneproductions) experienced many times while developing tools for Kubernetes that we were missing the ability to just call an apply or delete function that had the same behavior as Kubectl. We found ourselves, trying to implement the exact same logic as kubectl apply over and over again. This is of course a hassle, since we need to figure out how to create a specific resource or how to patch existing resources and choosing the correct patch method. 
+
+So we asked ourself... why reinvent the wheel? Kubectl has some nice commands that does this for us. But the code around kubectl can be really cumbersome and hard to understand. So for that reason we have implemented this little tool that simplifies the interface for all us developers.
+
+## Get started
+In order to get started you need to get the package to your project.
+```
+go get github.com/Arneproductions/go-kube
+```
+
+Now in order to use the functions you need to import the following package in your go file:
+```go
+import github.com/Arneproductions/go-kube/pkg/kubectl
+```
+
+This lets you call the functions like the following:
+```go
+opts := kubectl.ApplyManifestsOptions{
+    Recursive: false
+}
+
+kubectl.ApplyManifests(ctx, pathToKubeconfig, opts, pathToManifests...)
+```

--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -23,6 +23,24 @@ type deleteOptions struct {
 	IsKustomization bool `default:"false"`
 }
 
+/*
+DeleteManifests deletes the resource created by the given manifest files from the cluster that the kubeconfigPath points to.
+
+Example:
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := DeleteManifests(
+		ctx,
+		"/path/to/kubeconfig",
+		[]string{"path/to/file1", "path/to/file2"}...
+	)
+
+	if err != nil {
+		// Handle error
+	}
+*/
 func DeleteManifests(ctx context.Context, kubeconfigPath string, filePaths ...string) error {
 
 	opts := &deleteOptions{}
@@ -30,6 +48,24 @@ func DeleteManifests(ctx context.Context, kubeconfigPath string, filePaths ...st
 	return deleteFunc(ctx, kubeconfigPath, opts, filePaths...)
 }
 
+/*
+DeleteKustomization deletes the resources created by the given kustomization files from the cluster that the kubeconfigPath points to.
+
+Example:
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := DeleteKustomization(
+		ctx,
+		"/path/to/kubeconfig",
+		[]string{"path/to/kustomization1", "path/to/kustomization2"}...
+	)
+
+	if err != nil {
+		// Handle error
+	}
+*/
 func DeleteKustomization(ctx context.Context, kubeconfigPath string, filePaths ...string) error {
 
 	opts := &deleteOptions{}

--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -23,11 +23,16 @@ type deleteOptions struct {
 	IsKustomization bool `default:"false"`
 }
 
-func DeleteManifests(ctx context.Context, kubeconfigPath string, opts *deleteOptions, filePaths ...string) error {
+func DeleteManifests(ctx context.Context, kubeconfigPath string, filePaths ...string) error {
+
+	opts := &deleteOptions{}
+
 	return deleteFunc(ctx, kubeconfigPath, opts, filePaths...)
 }
 
-func DeleteKustomization(ctx context.Context, kubeconfigPath string, opts *deleteOptions, filePaths ...string) error {
+func DeleteKustomization(ctx context.Context, kubeconfigPath string, filePaths ...string) error {
+
+	opts := &deleteOptions{}
 	opts.IsKustomization = true // Force IsKustomization to true
 
 	return deleteFunc(ctx, kubeconfigPath, opts, filePaths...)


### PR DESCRIPTION
# Introduction
This PR is about creating a small section in the readme about why this is created and how to get started. Also we needed to look through some of the functions that and check that the code documentation is good enough. If not then it is added now.

A little plot twist is that the delete function signature had a private struct in the signature. That is being removed for now until we see an application for providing different run options.

fixes: #5 
fixes: #6 