### PR TITLE
Update go-build-and-test.yml

### DIFF
--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.21.4'
 


### PR DESCRIPTION
# Changes

- Updates the versions of the checkout and setup-go actions to current versions that doesn't depend on the deprecated nodejs version 16.

See warning msg on old run on action: https://github.com/Arneproductions/go-kube/actions/runs/7659334292