### PR TITLE
Add codeowner file

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @andreaswachs @Arneproductions


### PR DESCRIPTION
The codeowner file has been created according to the documentation at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners